### PR TITLE
Store categories in local storage

### DIFF
--- a/src/components/loader/Loader.js
+++ b/src/components/loader/Loader.js
@@ -3,7 +3,7 @@ import "./Loader.css";
 
 function Loader() {
   return (
-    <div className="loader-wrapper">
+    <div className="loader-wrapper" data-testid="loader">
       <div className="lds-roller">
         <div></div>
         <div></div>

--- a/src/components/main/categories/Categories.js
+++ b/src/components/main/categories/Categories.js
@@ -11,6 +11,10 @@ import {
   initialState,
   reducer,
 } from "../../../reducer/categoriesReducer";
+import {
+  getCategoriesFromLocalStorage,
+  setCategoriesToLocalStorage,
+} from "../../../utils/generic-utils";
 import "../../../styles/Categories.css";
 import axios from "axios";
 const difficultyLevelObject = [
@@ -68,7 +72,11 @@ function Categories() {
     async function fetchQuizCategories() {
       try {
         dispatch({ type: SET_FETCHING_INDICATOR, isFetchingData: true });
-        const quizCategories = (await axios.get(categoriesUrl)).data;
+        let quizCategories = getCategoriesFromLocalStorage();
+        if (!quizCategories.length) {
+          quizCategories = (await axios.get(categoriesUrl)).data;
+          setCategoriesToLocalStorage(quizCategories);
+        }
         // This dispatch will update categories, difficulty level and quizCategoryId since
         // category list is updated once on mount to avoid dispatching 3 state updates
         dispatch({

--- a/src/components/main/categories/Categories.js
+++ b/src/components/main/categories/Categories.js
@@ -72,10 +72,16 @@ function Categories() {
     async function fetchQuizCategories() {
       try {
         dispatch({ type: SET_FETCHING_INDICATOR, isFetchingData: true });
-        let quizCategories = getCategoriesFromLocalStorage();
+        // Categories data are saved to local storage using `quizCategories` key
+        let quizCategories = getCategoriesFromLocalStorage("quizCategories");
+        // If there are no categories data in local storage or they have expired,
+        // then fetch from DB
         if (!quizCategories.length) {
           quizCategories = (await axios.get(categoriesUrl)).data;
-          setCategoriesToLocalStorage(quizCategories);
+          setCategoriesToLocalStorage("quizCategories", {
+            dateSaved: Date.now(),
+            categories: quizCategories,
+          });
         }
         // This dispatch will update categories, difficulty level and quizCategoryId since
         // category list is updated once on mount to avoid dispatching 3 state updates
@@ -90,6 +96,8 @@ function Categories() {
         );
         dispatch({ type: SET_ERROR_INDICATOR, hasError: true });
       } finally {
+        // This is a memory leak if an error occurs because we are redirecting to
+        // the `/error` page yet the `finally` block will always execute
         dispatch({ type: SET_FETCHING_INDICATOR, isFetchingData: false });
       }
     }

--- a/src/components/main/categories/DropDownOptions.js
+++ b/src/components/main/categories/DropDownOptions.js
@@ -1,23 +1,11 @@
-import React, { useEffect, useRef } from "react";
-import { getSelectElementWidth } from "../../../utils/css-styles-utils";
+import React from "react";
 
 function DropDownOptions(props) {
   const { options, labelText, changeHandler } = props;
-  const selectRef = useRef(null);
-  useEffect(() => {
-    if (selectRef.current) {
-      selectRef.current.style.width = getSelectElementWidth();
-    }
-  }, []);
   return (
     <label>
       {labelText}
-      <select
-        onChange={changeHandler}
-        className="select"
-        id="select"
-        ref={selectRef}
-      >
+      <select onChange={changeHandler} className="select">
         {options.map((optionObject) => {
           return (
             <option

--- a/src/styles/Categories.css
+++ b/src/styles/Categories.css
@@ -4,6 +4,12 @@
   border: 1px solid transparent;
   margin: 0 0.2em;
   margin-left: 1em;
+  min-width: 269px;
+  /* 
+  Find a way of dynamically setting 
+  the width of difficulty level select 
+  element based on the width of category
+  select element */
 }
 
 .category__title {

--- a/src/tests/Categories.test.js
+++ b/src/tests/Categories.test.js
@@ -1,4 +1,6 @@
 import { render, screen, waitFor } from "@testing-library/react";
+import { rest } from "msw";
+import { setupServer } from "msw/node";
 import { Categories } from "../components/main/categories/Categories";
 import { Router } from "react-router-dom";
 import { createMemoryHistory } from "history";
@@ -11,6 +13,15 @@ const difficultyLevelObject = [
   { id: 1000, name: "Mixed" },
   { id: 1001, name: "Easy" },
 ];
+
+const server = setupServer(
+  rest.get(
+    "https://whizzniac-api.herokuapp.com/categories",
+    (req, res, ctx) => {
+      return res(ctx.status(200), ctx.json(categories));
+    }
+  )
+);
 
 describe("Render Categories component correctly", () => {
   describe("Render loading indicator", () => {
@@ -35,6 +46,49 @@ describe("Render Categories component correctly", () => {
       localStorage.removeItem("quizCategories");
     });
     it("Expect to render categories from local storage correctly", async () => {
+      render(
+        <Router history={createMemoryHistory()}>
+          <Categories />
+        </Router>
+      );
+      await waitFor(() => {
+        expect(
+          screen.getByText("Select category", { exact: true })
+        ).toBeInTheDocument();
+      });
+      expect(
+        screen.getByText("Select difficulty", { exact: true })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByLabelText("Category", { selector: "select", exact: true })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByLabelText("Difficulty", { selector: "select", exact: true })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("link", { name: "Start quiz", exact: true })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText("General Knowledge", { exact: true })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText("Entertainment: Books", { exact: true })
+      ).toBeInTheDocument();
+      expect(screen.getByText("Mixed", { exact: true })).toBeInTheDocument();
+      expect(screen.getByText("Easy", { exact: true })).toBeInTheDocument();
+    });
+  });
+
+  describe("Render categories from server", () => {
+    beforeAll(() => {
+      server.listen();
+    });
+
+    afterAll(() => {
+      server.close();
+    });
+
+    it("Expect to render categories from the server correctly", async () => {
       render(
         <Router history={createMemoryHistory()}>
           <Categories />

--- a/src/tests/Categories.test.js
+++ b/src/tests/Categories.test.js
@@ -1,0 +1,57 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { Categories } from "../components/main/categories/Categories";
+import { Router } from "react-router-dom";
+import { createMemoryHistory } from "history";
+const categories = [
+  { id: 9, name: "General Knowledge" },
+  { id: 10, name: "Entertainment: Books" },
+];
+// eslint-disable-next-line no-unused-vars
+const difficultyLevelObject = [
+  { id: 1000, name: "Mixed" },
+  { id: 1001, name: "Easy" },
+];
+
+beforeAll(() => {
+  localStorage.setItem(
+    "quizCategories",
+    JSON.stringify({ dateSaved: Date.now(), categories })
+  );
+});
+
+afterAll(() => {
+  localStorage.removeItem("quizCategories");
+});
+
+it("Expects to render Categories component correctly", async () => {
+  render(
+    <Router history={createMemoryHistory()}>
+      <Categories />
+    </Router>
+  );
+  await waitFor(() => {
+    expect(
+      screen.getByText("Select category", { exact: true })
+    ).toBeInTheDocument();
+  });
+  expect(
+    screen.getByText("Select difficulty", { exact: true })
+  ).toBeInTheDocument();
+  expect(
+    screen.getByLabelText("Category", { selector: "select", exact: true })
+  ).toBeInTheDocument();
+  expect(
+    screen.getByLabelText("Difficulty", { selector: "select", exact: true })
+  ).toBeInTheDocument();
+  expect(
+    screen.getByRole("link", { name: "Start quiz", exact: true })
+  ).toBeInTheDocument();
+  expect(
+    screen.getByText("General Knowledge", { exact: true })
+  ).toBeInTheDocument();
+  expect(
+    screen.getByText("Entertainment: Books", { exact: true })
+  ).toBeInTheDocument();
+  expect(screen.getByText("Mixed", { exact: true })).toBeInTheDocument();
+  expect(screen.getByText("Easy", { exact: true })).toBeInTheDocument();
+});

--- a/src/tests/Categories.test.js
+++ b/src/tests/Categories.test.js
@@ -12,46 +12,59 @@ const difficultyLevelObject = [
   { id: 1001, name: "Easy" },
 ];
 
-beforeAll(() => {
-  localStorage.setItem(
-    "quizCategories",
-    JSON.stringify({ dateSaved: Date.now(), categories })
-  );
-});
-
-afterAll(() => {
-  localStorage.removeItem("quizCategories");
-});
-
-it("Expects to render Categories component correctly", async () => {
-  render(
-    <Router history={createMemoryHistory()}>
-      <Categories />
-    </Router>
-  );
-  await waitFor(() => {
-    expect(
-      screen.getByText("Select category", { exact: true })
-    ).toBeInTheDocument();
+describe("Render Categories component correctly", () => {
+  describe("Render loading indicator", () => {
+    it("Expect to display loading indicator", () => {
+      render(
+        <Router history={createMemoryHistory()}>
+          <Categories />
+        </Router>
+      );
+      expect(screen.getByTestId("loader")).toBeInTheDocument();
+    });
   });
-  expect(
-    screen.getByText("Select difficulty", { exact: true })
-  ).toBeInTheDocument();
-  expect(
-    screen.getByLabelText("Category", { selector: "select", exact: true })
-  ).toBeInTheDocument();
-  expect(
-    screen.getByLabelText("Difficulty", { selector: "select", exact: true })
-  ).toBeInTheDocument();
-  expect(
-    screen.getByRole("link", { name: "Start quiz", exact: true })
-  ).toBeInTheDocument();
-  expect(
-    screen.getByText("General Knowledge", { exact: true })
-  ).toBeInTheDocument();
-  expect(
-    screen.getByText("Entertainment: Books", { exact: true })
-  ).toBeInTheDocument();
-  expect(screen.getByText("Mixed", { exact: true })).toBeInTheDocument();
-  expect(screen.getByText("Easy", { exact: true })).toBeInTheDocument();
+  describe("Render categories from local storage", () => {
+    beforeAll(() => {
+      localStorage.setItem(
+        "quizCategories",
+        JSON.stringify({ dateSaved: Date.now(), categories })
+      );
+    });
+
+    afterAll(() => {
+      localStorage.removeItem("quizCategories");
+    });
+    it("Expect to render categories from local storage correctly", async () => {
+      render(
+        <Router history={createMemoryHistory()}>
+          <Categories />
+        </Router>
+      );
+      await waitFor(() => {
+        expect(
+          screen.getByText("Select category", { exact: true })
+        ).toBeInTheDocument();
+      });
+      expect(
+        screen.getByText("Select difficulty", { exact: true })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByLabelText("Category", { selector: "select", exact: true })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByLabelText("Difficulty", { selector: "select", exact: true })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("link", { name: "Start quiz", exact: true })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText("General Knowledge", { exact: true })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText("Entertainment: Books", { exact: true })
+      ).toBeInTheDocument();
+      expect(screen.getByText("Mixed", { exact: true })).toBeInTheDocument();
+      expect(screen.getByText("Easy", { exact: true })).toBeInTheDocument();
+    });
+  });
 });

--- a/src/tests/generic-utils.test.js
+++ b/src/tests/generic-utils.test.js
@@ -1,4 +1,9 @@
-import { getRandomInteger, parseQueryString } from "../utils/generic-utils";
+import {
+  getRandomInteger,
+  parseQueryString,
+  setCategoriesToLocalStorage,
+  getCategoriesFromLocalStorage,
+} from "../utils/generic-utils";
 
 describe("Testing utility functions", () => {
   test("Tesing getRandomInteger", () => {
@@ -11,5 +16,9 @@ describe("Testing utility functions", () => {
     const parsedQueryStr = parseQueryString("?category=12");
     expect(typeof parseQueryString === "function").toBe(true);
     expect(parsedQueryStr).toEqual({ category: "12" });
+  });
+  test("Testing setCategoriesToLocalStorage and getCategoriesFromLocalStorage", () => {
+    expect(typeof setCategoriesToLocalStorage === "function").toBe(true);
+    expect(typeof getCategoriesFromLocalStorage === "function").toBe(true);
   });
 });

--- a/src/tests/generic-utils.test.js
+++ b/src/tests/generic-utils.test.js
@@ -17,8 +17,37 @@ describe("Testing utility functions", () => {
     expect(typeof parseQueryString === "function").toBe(true);
     expect(parsedQueryStr).toEqual({ category: "12" });
   });
-  test("Testing setCategoriesToLocalStorage and getCategoriesFromLocalStorage", () => {
+  test("Testing setCategoriesToLocalStorage", () => {
+    setCategoriesToLocalStorage("testing", { a: 1, b: 2 });
     expect(typeof setCategoriesToLocalStorage === "function").toBe(true);
+    expect(JSON.parse(localStorage.getItem("testing"))).toEqual({ a: 1, b: 2 });
+    localStorage.removeItem("testing");
+  });
+  test("Testing getCategoriesFromLocalStorage", () => {
+    const oneDay = 1 * 24 * 60 * 60 * 1000; // ms
+    const now = Date.now();
+    localStorage.setItem(
+      "savedAfterOneWeek",
+      JSON.stringify({
+        dateSaved: now - 8 * oneDay,
+        categories: [{ a: 1 }],
+      })
+    );
+    localStorage.setItem(
+      "savedWithinOneWeek",
+      JSON.stringify({
+        dateSaved: now,
+        categories: [{ a: 1 }],
+      })
+    );
+
     expect(typeof getCategoriesFromLocalStorage === "function").toBe(true);
+    expect(getCategoriesFromLocalStorage("nonExistentKey")).toEqual([]);
+    expect(getCategoriesFromLocalStorage("savedAfterOneWeek")).toEqual([]);
+    expect(getCategoriesFromLocalStorage("savedWithinOneWeek")).toEqual([
+      { a: 1 },
+    ]);
+    localStorage.removeItem("savedAfterOneWeek");
+    localStorage.removeItem("savedWithinOneWeek");
   });
 });

--- a/src/utils/css-styles-utils.js
+++ b/src/utils/css-styles-utils.js
@@ -10,8 +10,4 @@ function getViewportHeight() {
   );
 }
 
-function getSelectElementWidth() {
-  const selectElement = document.querySelector("#select");
-  return selectElement ? `${selectElement.offsetWidth}px` : "auto";
-}
-export { getHeaderHeight, getViewportHeight, getSelectElementWidth };
+export { getHeaderHeight, getViewportHeight };

--- a/src/utils/generic-utils.js
+++ b/src/utils/generic-utils.js
@@ -147,8 +147,8 @@ function formatDate(date) {
  * @returns any[]
  */
 
-function getCategoriesFromLocalStorage() {
-  const savedCategories = localStorage.getItem("quiz-categories");
+function getCategoriesFromLocalStorage(key) {
+  const savedCategories = localStorage.getItem(key);
   if (!savedCategories) return [];
   const { dateSaved, categories } = JSON.parse(savedCategories);
   const oneWeek = 7 * 24 * 60 * 60 * 1000;
@@ -157,14 +157,12 @@ function getCategoriesFromLocalStorage() {
 
 /**
  * Sets categories to local storage
- * @param {any[]} categories
+ * @param {string} key
+ * @param {object} data
  */
 
-function setCategoriesToLocalStorage(categories) {
-  localStorage.setItem(
-    "quiz-categories",
-    JSON.stringify({ dateSaved: Date.now(), categories })
-  );
+function setCategoriesToLocalStorage(key, data) {
+  localStorage.setItem(key, JSON.stringify(data));
 }
 
 /**

--- a/src/utils/generic-utils.js
+++ b/src/utils/generic-utils.js
@@ -143,6 +143,31 @@ function formatDate(date) {
 }
 
 /**
+ * Gets categories from localstorage
+ * @returns any[]
+ */
+
+function getCategoriesFromLocalStorage() {
+  const savedCategories = localStorage.getItem("quiz-categories");
+  if (!savedCategories) return [];
+  const { dateSaved, categories } = JSON.parse(savedCategories);
+  const oneWeek = 7 * 24 * 60 * 60 * 1000;
+  return Date.now() - dateSaved < oneWeek ? categories : [];
+}
+
+/**
+ * Sets categories to local storage
+ * @param {any[]} categories
+ */
+
+function setCategoriesToLocalStorage(categories) {
+  localStorage.setItem(
+    "quiz-categories",
+    JSON.stringify({ dateSaved: Date.now(), categories })
+  );
+}
+
+/**
  * Gets token from local storage
  * @returns {string}
  */
@@ -217,6 +242,8 @@ export {
   computeScore,
   getTokenFromLocalStorage,
   setTokenToLocalStorage,
+  setCategoriesToLocalStorage,
+  getCategoriesFromLocalStorage,
   formatDate,
   isLastQuestion,
   isLastQuestionAttempted,


### PR DESCRIPTION
This PR adds code for storing categories data in local storage instead of fetching it from the server. The data stored in local storage is valid for one week. 

And it also fixes the width of `.select` element to `269px`.

Fixes #49 